### PR TITLE
fix lur_redux version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,4 +32,4 @@ gem "sinatra-cross_origin", "~> 0.3.1"
 
 gem 'sinatra-session'
 
-gem 'lru_redux'
+gem 'lru_redux', "~> 1.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
     httparty (0.16.1)
       multi_xml (>= 0.5.2)
     kgio (2.11.2)
-    lru_redux (0.8.4)
+    lru_redux (1.1.0)
     memoist (0.16.0)
     method_source (0.9.0)
     multi_xml (0.6.0)
@@ -49,7 +49,7 @@ PLATFORMS
 DEPENDENCIES
   foreman
   httparty
-  lru_redux
+  lru_redux (~> 1.1.0)
   memoist
   oj
   pry


### PR DESCRIPTION
According to the [Changelog](https://github.com/SamSaffron/lru_redux#changelog), the TTL cache used by this project was added since version 1.1.0.